### PR TITLE
Accept a size-0 history array in step()

### DIFF
--- a/src/mjbatch/csrc/batch.h
+++ b/src/mjbatch/csrc/batch.h
@@ -426,8 +426,11 @@ class Batch {
     if (a.dtype() != nb::dtype<mjtNum>()) {
       throw nb::value_error((std::string("history must be ") + DtypeName(Elem::Num)).c_str());
     }
-    if (a.device_type() != nb::device::cpu::value || a.stride(2) != 1 || a.stride(1) != nstate_ ||
-        a.stride(0) != static_cast<int64_t>(nstep) * nstate_) {
+    // A size-0 array (an empty selection) is never written, so its strides are
+    // irrelevant; numpy sets them all to zero regardless of contiguity.
+    if (a.device_type() != nb::device::cpu::value ||
+        (a.size() != 0 && (a.stride(2) != 1 || a.stride(1) != nstate_ ||
+                           a.stride(0) != static_cast<int64_t>(nstep) * nstate_))) {
       throw nb::value_error("history must be a C-contiguous CPU array");
     }
     return static_cast<mjtNum*>(a.data());

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -297,6 +297,15 @@ def test_step_history_validation(model):
   assert not np.any(batch.bind("time"))
 
 
+def test_step_history_allows_an_empty_selection(model):
+  # A size-0 history has nothing written to it, so its strides are irrelevant
+  # (numpy sets them to zero); it must not be rejected as non-contiguous.
+  batch = Batch(model, N)
+  batch.step(np.zeros(N, dtype=bool), nstep=3, history=np.empty((0, 3, batch.nstate)))
+  batch.step(np.array([], dtype=np.int64), nstep=2, history=np.empty((0, 2, batch.nstate)))
+  assert not np.any(batch.bind("time"))
+
+
 def test_step_history_error_names_the_sim():
   batch = Batch(mujoco.MjModel.from_xml_string(LOCKSTEP_XML), N, num_threads=2)
   batch.expand("eq_type")[2] = 99


### PR DESCRIPTION
numpy sets every stride of a zero-size array to zero, so the literal stride checks in HistoryPtr rejected an empty but valid history as non-C-contiguous: step(ids=<empty selection>, nstep=k, history=np.empty((0, k, nstate))) raised "history must be a C-contiguous CPU array" even though nothing would be written to it.

Skip the stride checks for a size-0 array.