### PR TITLE
Accept any history array numpy considers C-contiguous.

### DIFF
--- a/src/mjbatch/csrc/batch.h
+++ b/src/mjbatch/csrc/batch.h
@@ -66,6 +66,17 @@ inline const char* DtypeName(Elem e) {
   }
 }
 
+// numpy's rule: an extent-1 axis may carry any stride and a size-0 array is contiguous.
+inline bool IsCContig(const nb::ndarray<>& a) {
+  if (a.size() == 0) return true;
+  int64_t expect = 1;
+  for (size_t i = a.ndim(); i-- > 0;) {
+    if (a.shape(i) != 1 && a.stride(i) != expect) return false;
+    expect *= static_cast<int64_t>(a.shape(i));
+  }
+  return true;
+}
+
 // One array field of mjModel or mjData, sized for a specific model.
 struct FieldInfo {
   const char* name;
@@ -426,8 +437,7 @@ class Batch {
     if (a.dtype() != nb::dtype<mjtNum>()) {
       throw nb::value_error((std::string("history must be ") + DtypeName(Elem::Num)).c_str());
     }
-    if (a.device_type() != nb::device::cpu::value || a.stride(2) != 1 || a.stride(1) != nstate_ ||
-        a.stride(0) != static_cast<int64_t>(nstep) * nstate_) {
+    if (a.device_type() != nb::device::cpu::value || !IsCContig(a)) {
       throw nb::value_error("history must be a C-contiguous CPU array");
     }
     return static_cast<mjtNum*>(a.data());

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -297,6 +297,16 @@ def test_step_history_validation(model):
   assert not np.any(batch.bind("time"))
 
 
+def test_step_history_accepts_degenerate_strides(model):
+  # numpy gives a size-0 array all-zero strides and a new axis a zero stride.
+  batch = Batch(model, N)
+  batch.step(np.zeros(N, dtype=bool), nstep=3, history=np.empty((0, 3, batch.nstate)))
+  history = np.empty((4, batch.nstate))
+  batch.step(np.array([2]), nstep=4, history=history[None])
+  np.testing.assert_array_equal(history[-1], batch.bind("state")[2])
+  assert not np.any(np.delete(batch.bind("time"), 2))
+
+
 def test_step_history_error_names_the_sim():
   batch = Batch(mujoco.MjModel.from_xml_string(LOCKSTEP_XML), N, num_threads=2)
   batch.expand("eq_type")[2] = 99


### PR DESCRIPTION
Accept any history array numpy considers C-contiguous.